### PR TITLE
Add image generation script for text and markdown files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "build": {
+    "args": {
+      "INSTALL_PYTHON_PACKAGES": "pip install pillow textwrap3"
+    }
+  },
+  "tasks": {
+    "build": "pip install pillow textwrap3",
+    "test": "echo \"There are no tests that need running\"",
+    "launch": "python generate_images.py"
+  }
+}

--- a/generate_images.py
+++ b/generate_images.py
@@ -1,0 +1,56 @@
+import os
+from PIL import Image, ImageDraw, ImageFont
+import textwrap
+
+def create_image_from_text(text, output_path):
+    # Define image size and font
+    width, height = 800, 600
+    background_color = "white"
+    text_color = "black"
+    border_size = 10
+    font = ImageFont.load_default()
+
+    # Create a new image with white background
+    image = Image.new("RGB", (width, height), background_color)
+    draw = ImageDraw.Draw(image)
+
+    # Wrap the text to fit within the image width
+    wrapped_text = textwrap.fill(text, width=70)
+
+    # Calculate text size and position
+    text_size = draw.textsize(wrapped_text, font=font)
+    text_x = (width - text_size[0]) // 2
+    text_y = (height - text_size[1]) // 2
+
+    # Draw the text on the image
+    draw.text((text_x, text_y), wrapped_text, font=font, fill=text_color)
+
+    # Add a border to the image
+    image_with_border = Image.new("RGB", (width + 2 * border_size, height + 2 * border_size), background_color)
+    image_with_border.paste(image, (border_size, border_size))
+
+    # Save the image as JPEG and PNG
+    image_with_border.save(output_path + ".jpg", "JPEG")
+    image_with_border.save(output_path + ".png", "PNG")
+
+def process_files(directory, output_directory):
+    for root, _, files in os.walk(directory):
+        subdir_name = os.path.basename(root)
+        image_counter = 1
+
+        for file in files:
+            if file.endswith((".md", ".txt", ".py", ".rb")):
+                file_path = os.path.join(root, file)
+                with open(file_path, "r") as f:
+                    text = f.read()
+
+                output_path = os.path.join(output_directory, f"{subdir_name}_{image_counter}")
+                create_image_from_text(text, output_path)
+                image_counter += 1
+
+if __name__ == "__main__":
+    output_directory = "malicious-images"
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
+
+    process_files(".", output_directory)

--- a/generate_images.py
+++ b/generate_images.py
@@ -43,16 +43,20 @@ def process_files(directory, output_directory):
         for file in files:
             if file.endswith((".md", ".txt", ".py", ".rb")):
                 file_path = os.path.join(root, file)
-                with open(file_path, "r") as f:
+                print(f"Processing file: {file_path}")
+                with open(file_path, "r", encoding='utf-8', errors='ignore') as f:
                     text = f.read()
 
                 output_path = os.path.join(output_directory, f"{subdir_name}_{image_counter}")
                 create_image_from_text(text, output_path)
+                print(f"Created images: {output_path}.jpg and {output_path}.png")
                 image_counter += 1
 
 if __name__ == "__main__":
     output_directory = "malicious-images"
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
+        print(f"Created directory: {output_directory}")
 
     process_files(".", output_directory)
+    print("Image generation completed.")

--- a/generate_images.py
+++ b/generate_images.py
@@ -18,9 +18,11 @@ def create_image_from_text(text, output_path):
     wrapped_text = textwrap.fill(text, width=70)
 
     # Calculate text size and position
-    text_size = draw.textsize(wrapped_text, font=font)
-    text_x = (width - text_size[0]) // 2
-    text_y = (height - text_size[1]) // 2
+    text_bbox = draw.textbbox((0, 0), wrapped_text, font=font)
+    text_width = text_bbox[2] - text_bbox[0]
+    text_height = text_bbox[3] - text_bbox[1]
+    text_x = (width - text_width) // 2
+    text_y = (height - text_height) // 2
 
     # Draw the text on the image
     draw.text((text_x, text_y), wrapped_text, font=font, fill=text_color)


### PR DESCRIPTION
Add a new script `generate_images.py` to recursively process text and markdown files and create JPEG and PNG images.

* Import necessary libraries: `os`, `PIL` (Pillow), `textwrap`
* Define `create_image_from_text` function to generate images from text
* Define `process_files` function to recursively process `.md`, `.txt`, and source code files
* Create a new top-level directory named `malicious-images` to store generated images
* Save generated images as JPEG and PNG files with names based on sub-directory and counter to avoid duplicates

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lshep-bf/PayloadsAllTheThings/pull/1?shareId=d40990ce-3fa8-4a71-966c-f1da42118142).